### PR TITLE
perf: improve VRF fulfillment latency

### DIFF
--- a/vrf-oracle/src/oracle/client.rs
+++ b/vrf-oracle/src/oracle/client.rs
@@ -386,15 +386,16 @@ impl OracleClient {
                     info!("Update source connected successfully");
                     // Requests that landed while the source was down produce no
                     // account notification: snapshot on every (re)connect,
-                    // spawned so a slow scan cannot stall stream consumption.
-                    // A scan already in flight is left to finish; the periodic
-                    // pass covers anything it predates.
-                    if let Ok(scan_guard) = Arc::clone(&scan_lock).try_lock_owned() {
+                    // spawned so a slow scan cannot stall stream consumption
+                    // and queued behind any scan already in flight (whose bank
+                    // may predate the gap).
+                    {
+                        let scan_lock = Arc::clone(&scan_lock);
                         let self_clone = Arc::clone(&self);
                         let rpc_client_clone = Arc::clone(&rpc_client);
                         let blockhash_cache_clone = Arc::clone(&blockhash_cache);
                         tokio::spawn(async move {
-                            let _scan_guard = scan_guard;
+                            let _scan_guard = scan_lock.lock_owned().await;
                             if let Err(err) = fetch_and_process_program_accounts(
                                 &self_clone,
                                 &rpc_client_clone,

--- a/vrf-oracle/src/oracle/client.rs
+++ b/vrf-oracle/src/oracle/client.rs
@@ -237,6 +237,7 @@ pub struct OracleClient {
     pub slot_tracker: SlotTracker,
     delegated_queue_statuses: Arc<RwLock<Option<HashMap<Pubkey, bool>>>>,
     priority_fee_cache: Arc<RwLock<Option<(u64, Instant)>>>,
+    priority_fee_refresh: Arc<tokio::sync::Mutex<()>>,
 }
 
 #[async_trait]
@@ -272,6 +273,7 @@ impl OracleClient {
             slot_tracker: SlotTracker::new(),
             delegated_queue_statuses: Arc::new(RwLock::new(None)),
             priority_fee_cache: Arc::new(RwLock::new(None)),
+            priority_fee_refresh: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 
@@ -282,16 +284,25 @@ impl OracleClient {
         if self.delegated_queue_statuses.read().await.is_some() {
             return 0;
         }
-        if let Some((fee, fetched_at)) = *self.priority_fee_cache.read().await {
-            if fetched_at.elapsed() < PRIORITY_FEE_MAX_AGE {
-                return fee;
-            }
+        if let Some(fee) = self.cached_priority_fee().await {
+            return fee;
+        }
+        // Serialize refreshes so concurrent tasks share one estimate.
+        let _refresh_guard = self.priority_fee_refresh.lock().await;
+        if let Some(fee) = self.cached_priority_fee().await {
+            return fee;
         }
         let fee = Self::fetch_priority_fee(rpc_client)
             .await
             .unwrap_or(DEFAULT_PRIORITY_FEE_MICRO_LAMPORTS);
         *self.priority_fee_cache.write().await = Some((fee, Instant::now()));
         fee
+    }
+
+    async fn cached_priority_fee(&self) -> Option<u64> {
+        (*self.priority_fee_cache.read().await)
+            .filter(|(_, fetched_at)| fetched_at.elapsed() < PRIORITY_FEE_MAX_AGE)
+            .map(|(fee, _)| fee)
     }
 
     async fn fetch_priority_fee(rpc_client: &RpcClient) -> Result<u64, ClientError> {
@@ -364,16 +375,26 @@ impl OracleClient {
                 Ok(mut source) => {
                     info!("Update source connected successfully");
                     // Requests that landed while the source was down produce no
-                    // account notification: snapshot on every (re)connect.
-                    if let Err(err) = fetch_and_process_program_accounts(
-                        &self,
-                        &rpc_client,
-                        &blockhash_cache,
-                        queue_memcmp_filter(),
-                    )
-                    .await
+                    // account notification: snapshot on every (re)connect,
+                    // spawned so a slow scan cannot stall stream consumption.
                     {
-                        error!("Post-connect fetch_and_process_program_accounts failed: {err:?}");
+                        let self_clone = Arc::clone(&self);
+                        let rpc_client_clone = Arc::clone(&rpc_client);
+                        let blockhash_cache_clone = Arc::clone(&blockhash_cache);
+                        tokio::spawn(async move {
+                            if let Err(err) = fetch_and_process_program_accounts(
+                                &self_clone,
+                                &rpc_client_clone,
+                                &blockhash_cache_clone,
+                                queue_memcmp_filter(),
+                            )
+                            .await
+                            {
+                                error!(
+                                    "Post-connect fetch_and_process_program_accounts failed: {err:?}"
+                                );
+                            }
+                        });
                     }
                     while let Some((pubkey, queue, bytes, notification_slot)) = source.next().await
                     {

--- a/vrf-oracle/src/oracle/client.rs
+++ b/vrf-oracle/src/oracle/client.rs
@@ -12,7 +12,10 @@ use solana_commitment_config::CommitmentConfig;
 use solana_sdk::{pubkey::Pubkey, signature::Keypair};
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
     time::Duration,
 };
 use tokio::sync::{watch, RwLock};
@@ -352,6 +355,7 @@ impl OracleClient {
         // Serialize full-program scans: the periodic and reconnect paths
         // share one flight so a slow RPC cannot accumulate overlapping scans.
         let scan_lock = Arc::new(tokio::sync::Mutex::new(()));
+        let scan_queued = Arc::new(AtomicBool::new(false));
 
         // Periodically refresh and process program accounts every 5 seconds
         {
@@ -388,14 +392,17 @@ impl OracleClient {
                     // account notification: snapshot on every (re)connect,
                     // spawned so a slow scan cannot stall stream consumption
                     // and queued behind any scan already in flight (whose bank
-                    // may predate the gap).
-                    {
+                    // may predate the gap). At most one snapshot waits: a
+                    // pending one covers every later gap as well.
+                    if !scan_queued.swap(true, Ordering::SeqCst) {
                         let scan_lock = Arc::clone(&scan_lock);
+                        let scan_queued = Arc::clone(&scan_queued);
                         let self_clone = Arc::clone(&self);
                         let rpc_client_clone = Arc::clone(&rpc_client);
                         let blockhash_cache_clone = Arc::clone(&blockhash_cache);
                         tokio::spawn(async move {
                             let _scan_guard = scan_lock.lock_owned().await;
+                            scan_queued.store(false, Ordering::SeqCst);
                             if let Err(err) = fetch_and_process_program_accounts(
                                 &self_clone,
                                 &rpc_client_clone,

--- a/vrf-oracle/src/oracle/client.rs
+++ b/vrf-oracle/src/oracle/client.rs
@@ -59,6 +59,7 @@ struct DelegationStatusResponse {
 }
 
 const PRIORITY_FEE_MAX_AGE: Duration = Duration::from_secs(10);
+const PRIORITY_FEE_FETCH_TIMEOUT: Duration = Duration::from_millis(500);
 const DEFAULT_PRIORITY_FEE_MICRO_LAMPORTS: u64 = 10_000;
 const EARLY_SEND_DIVISOR: u32 = 20;
 const EARLY_SEND_MAX: Duration = Duration::from_millis(20);
@@ -298,9 +299,19 @@ impl OracleClient {
         if let Some(fee) = self.cached_priority_fee().await {
             return fee;
         }
-        let fee = Self::fetch_priority_fee(rpc_client)
-            .await
-            .unwrap_or(DEFAULT_PRIORITY_FEE_MICRO_LAMPORTS);
+        // Bound the refresh so a slow endpoint cannot delay sends; fall back
+        // to the last known value and retry next window.
+        let fee = match tokio::time::timeout(
+            PRIORITY_FEE_FETCH_TIMEOUT,
+            Self::fetch_priority_fee(rpc_client),
+        )
+        .await
+        {
+            Ok(Ok(fee)) => fee,
+            _ => (*self.priority_fee_cache.read().await)
+                .map(|(fee, _)| fee)
+                .unwrap_or(DEFAULT_PRIORITY_FEE_MICRO_LAMPORTS),
+        };
         *self.priority_fee_cache.write().await = Some((fee, Instant::now()));
         fee
     }

--- a/vrf-oracle/src/oracle/client.rs
+++ b/vrf-oracle/src/oracle/client.rs
@@ -55,6 +55,8 @@ struct DelegationStatusResponse {
     is_delegated: bool,
 }
 
+const PRIORITY_FEE_MAX_AGE: Duration = Duration::from_secs(10);
+const DEFAULT_PRIORITY_FEE_MICRO_LAMPORTS: u64 = 10_000;
 const EARLY_SEND_DIVISOR: u32 = 20;
 const EARLY_SEND_MAX: Duration = Duration::from_millis(20);
 const NON_ER_EARLY_SEND_BONUS: Duration = Duration::from_millis(400);
@@ -234,6 +236,7 @@ pub struct OracleClient {
     pub skip_preflight: bool,
     pub slot_tracker: SlotTracker,
     delegated_queue_statuses: Arc<RwLock<Option<HashMap<Pubkey, bool>>>>,
+    priority_fee_cache: Arc<RwLock<Option<(u64, Instant)>>>,
 }
 
 #[async_trait]
@@ -268,7 +271,47 @@ impl OracleClient {
             skip_preflight,
             slot_tracker: SlotTracker::new(),
             delegated_queue_statuses: Arc::new(RwLock::new(None)),
+            priority_fee_cache: Arc::new(RwLock::new(None)),
         }
+    }
+
+    /// Recommended priority fee in micro-lamports per CU, cached for
+    /// PRIORITY_FEE_MAX_AGE. Zero on ephemeral rollups; falls back to the
+    /// default when the endpoint does not support getPriorityFeeEstimate.
+    pub async fn priority_fee(&self, rpc_client: &RpcClient) -> u64 {
+        if self.delegated_queue_statuses.read().await.is_some() {
+            return 0;
+        }
+        if let Some((fee, fetched_at)) = *self.priority_fee_cache.read().await {
+            if fetched_at.elapsed() < PRIORITY_FEE_MAX_AGE {
+                return fee;
+            }
+        }
+        let fee = Self::fetch_priority_fee(rpc_client)
+            .await
+            .unwrap_or(DEFAULT_PRIORITY_FEE_MICRO_LAMPORTS);
+        *self.priority_fee_cache.write().await = Some((fee, Instant::now()));
+        fee
+    }
+
+    async fn fetch_priority_fee(rpc_client: &RpcClient) -> Result<u64, ClientError> {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct PriorityFeeEstimate {
+            priority_fee_estimate: f64,
+        }
+        rpc_client
+            .send::<PriorityFeeEstimate>(
+                RpcRequest::Custom {
+                    method: "getPriorityFeeEstimate",
+                },
+                json!([{
+                    "accountKeys": [PROGRAM_ID.to_string()],
+                    "options": { "recommended": true }
+                }]),
+            )
+            .await
+            .map(|estimate| estimate.priority_fee_estimate as u64)
     }
 
     pub async fn run(self: Arc<Self>) -> Result<()> {
@@ -292,13 +335,13 @@ impl OracleClient {
         )
         .await?;
 
-        // Periodically refresh and process program accounts every 30 seconds
+        // Periodically refresh and process program accounts every 5 seconds
         {
             let self_clone = Arc::clone(&self);
             let rpc_client_clone = Arc::clone(&rpc_client);
             let blockhash_cache_clone = Arc::clone(&blockhash_cache);
             tokio::spawn(async move {
-                let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
+                let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
                 interval.tick().await;
                 loop {
                     interval.tick().await;
@@ -320,6 +363,18 @@ impl OracleClient {
             match self.create_update_source(&blockhash_cache).await {
                 Ok(mut source) => {
                     info!("Update source connected successfully");
+                    // Requests that landed while the source was down produce no
+                    // account notification: snapshot on every (re)connect.
+                    if let Err(err) = fetch_and_process_program_accounts(
+                        &self,
+                        &rpc_client,
+                        &blockhash_cache,
+                        queue_memcmp_filter(),
+                    )
+                    .await
+                    {
+                        error!("Post-connect fetch_and_process_program_accounts failed: {err:?}");
+                    }
                     while let Some((pubkey, queue, bytes, notification_slot)) = source.next().await
                     {
                         let bytes = Arc::new(bytes);

--- a/vrf-oracle/src/oracle/client.rs
+++ b/vrf-oracle/src/oracle/client.rs
@@ -346,16 +346,23 @@ impl OracleClient {
         )
         .await?;
 
+        // Serialize full-program scans: the periodic and reconnect paths
+        // share one flight so a slow RPC cannot accumulate overlapping scans.
+        let scan_lock = Arc::new(tokio::sync::Mutex::new(()));
+
         // Periodically refresh and process program accounts every 5 seconds
         {
             let self_clone = Arc::clone(&self);
             let rpc_client_clone = Arc::clone(&rpc_client);
             let blockhash_cache_clone = Arc::clone(&blockhash_cache);
+            let scan_lock_clone = Arc::clone(&scan_lock);
             tokio::spawn(async move {
                 let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
                 interval.tick().await;
                 loop {
                     interval.tick().await;
+                    let _scan_guard = scan_lock_clone.lock().await;
                     if let Err(err) = fetch_and_process_program_accounts(
                         &self_clone,
                         &rpc_client_clone,
@@ -377,11 +384,14 @@ impl OracleClient {
                     // Requests that landed while the source was down produce no
                     // account notification: snapshot on every (re)connect,
                     // spawned so a slow scan cannot stall stream consumption.
-                    {
+                    // A scan already in flight is left to finish; the periodic
+                    // pass covers anything it predates.
+                    if let Ok(scan_guard) = Arc::clone(&scan_lock).try_lock_owned() {
                         let self_clone = Arc::clone(&self);
                         let rpc_client_clone = Arc::clone(&rpc_client);
                         let blockhash_cache_clone = Arc::clone(&blockhash_cache);
                         tokio::spawn(async move {
+                            let _scan_guard = scan_guard;
                             if let Err(err) = fetch_and_process_program_accounts(
                                 &self_clone,
                                 &rpc_client_clone,

--- a/vrf-oracle/src/oracle/client.rs
+++ b/vrf-oracle/src/oracle/client.rs
@@ -420,6 +420,7 @@ impl OracleClient {
                             &queue,
                             bytes,
                             Some(notification_slot),
+                            false,
                         )
                         .await;
                     }

--- a/vrf-oracle/src/oracle/client.rs
+++ b/vrf-oracle/src/oracle/client.rs
@@ -238,6 +238,8 @@ pub struct OracleClient {
     delegated_queue_statuses: Arc<RwLock<Option<HashMap<Pubkey, bool>>>>,
     priority_fee_cache: Arc<RwLock<Option<(u64, Instant)>>>,
     priority_fee_refresh: Arc<tokio::sync::Mutex<()>>,
+    // Newest view slot processed per queue; older views are discarded.
+    pub latest_view_slots: Arc<RwLock<HashMap<QueueKey, u64>>>,
 }
 
 #[async_trait]
@@ -274,6 +276,7 @@ impl OracleClient {
             delegated_queue_statuses: Arc::new(RwLock::new(None)),
             priority_fee_cache: Arc::new(RwLock::new(None)),
             priority_fee_refresh: Arc::new(tokio::sync::Mutex::new(())),
+            latest_view_slots: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 

--- a/vrf-oracle/src/oracle/processor.rs
+++ b/vrf-oracle/src/oracle/processor.rs
@@ -34,7 +34,7 @@ use tokio::task;
 
 const ANCHOR_CONSTRAINT_ADDRESS_ERROR: u32 = 2012;
 const BLOCKHASH_MAX_AGE: Duration = Duration::from_secs(3);
-const MAX_PRIORITY_FEE_MICRO_LAMPORTS: u64 = 200_000;
+const MAX_PRIORITY_FEE_LAMPORTS: u64 = 60_000;
 
 pub async fn fetch_and_process_program_accounts(
     oracle_client: &Arc<OracleClient>,
@@ -483,9 +483,10 @@ impl ProcessableItem {
         // transaction under the same cached blockhash.
         let budget = budget + (attempt % 256) as u32;
         // Escalate the fee roughly every 3s the request stays unlanded; the
-        // cap bounds the spend to ~60k lamports at the 300k CU limit.
-        let priority_fee = (oracle_client.priority_fee(rpc_client).await << (attempt / 8).min(4))
-            .min(MAX_PRIORITY_FEE_MICRO_LAMPORTS);
+        // cap bounds the total priority spend per attempt for any CU limit.
+        let max_price = MAX_PRIORITY_FEE_LAMPORTS.saturating_mul(1_000_000) / u64::from(budget);
+        let priority_fee =
+            (oracle_client.priority_fee(rpc_client).await << (attempt / 8).min(4)).min(max_price);
         let mut instructions = vec![ComputeBudgetInstruction::set_compute_unit_limit(budget), ix];
         if priority_fee > 0 {
             // Appended after the VRF instruction so its error index stays 1,

--- a/vrf-oracle/src/oracle/processor.rs
+++ b/vrf-oracle/src/oracle/processor.rs
@@ -69,8 +69,12 @@ pub async fn fetch_and_process_program_accounts(
         )
         .await?;
     let (view_slot, keyed_accounts) = match response {
-        OptionalContext::Context(response) => (Some(response.context.slot), response.value),
-        OptionalContext::NoContext(value) => (None, value),
+        OptionalContext::Context(response) => (response.context.slot, response.value),
+        // A contextless response cannot be ordered against live
+        // notifications; treat it as a failed scan and retry later.
+        OptionalContext::NoContext(_) => {
+            anyhow::bail!("getProgramAccounts returned no context slot")
+        }
     };
     let accounts: Vec<(Pubkey, Account)> = keyed_accounts
         .into_iter()
@@ -104,7 +108,7 @@ pub async fn fetch_and_process_program_accounts(
                     &pubkey,
                     queue,
                     Arc::clone(&bytes),
-                    view_slot,
+                    Some(view_slot),
                 )
                 .await
             })
@@ -133,6 +137,18 @@ pub async fn process_oracle_queue(
     if oracle_queue_pda(&oracle_client.keypair.pubkey(), oracle_queue.index).0 == *queue
         && oracle_client.should_process_queue(rpc_client, queue).await
     {
+        // Process views in slot order per queue: an older snapshot racing a
+        // newer notification could otherwise resurrect a completed request
+        // (spawning a duplicate fulfillment) or cancel a live one.
+        if let Some(view_slot) = notification_slot {
+            let mut latest_views = oracle_client.latest_view_slots.write().await;
+            let latest = latest_views.entry(queue.to_string()).or_insert(0);
+            if view_slot < *latest {
+                return;
+            }
+            *latest = view_slot;
+        }
+
         if oracle_queue.item_count > 0 {
             info!(
                 "Processing queue: {}, with len: {}",

--- a/vrf-oracle/src/oracle/processor.rs
+++ b/vrf-oracle/src/oracle/processor.rs
@@ -13,15 +13,19 @@ use ephemeral_vrf_api::{
 use futures_util::future::join_all;
 use futures_util::FutureExt;
 use log::{error, info, trace, warn};
+use serde_json::json;
 use solana_account_decoder::UiAccountEncoding;
 use solana_client::client_error::ClientError;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_client::rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig};
 use solana_client::rpc_filter::RpcFilterType;
+use solana_client::rpc_request::RpcRequest;
+use solana_client::rpc_response::{OptionalContext, RpcKeyedAccount};
 use solana_commitment_config::{CommitmentConfig, CommitmentLevel};
 use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_curve25519::{ristretto::PodRistrettoPoint, scalar::PodScalar};
 use solana_sdk::{
+    account::Account,
     instruction::InstructionError,
     pubkey::Pubkey,
     signature::Signer,
@@ -42,25 +46,36 @@ pub async fn fetch_and_process_program_accounts(
     blockhash_cache: &Arc<BlockhashCache>,
     filters: Vec<RpcFilterType>,
 ) -> Result<()> {
-    // min_context_slot binds the scan to this view, so absences in the
-    // result are meaningful for items enqueued strictly before it. Minus
-    // one because the tracker may already know a just-created bank the
-    // RPC node has not finished processing.
-    let view_slot = oracle_client.slot_tracker.current().saturating_sub(1);
     let config = RpcProgramAccountsConfig {
         account_config: RpcAccountInfoConfig {
             commitment: Some(CommitmentConfig::processed()),
             encoding: Some(UiAccountEncoding::Base64),
-            min_context_slot: Some(view_slot),
             ..Default::default()
         },
         filters: Some(filters),
+        with_context: Some(true),
         ..Default::default()
     };
 
-    let accounts = rpc_client
-        .get_program_accounts_with_config(&PROGRAM_ID, config)
+    // The response's context slot is the exact bank the scan was evaluated
+    // at, so absences in it are meaningful for items enqueued strictly
+    // earlier. Never demand a minimum slot here: the tracker follows the
+    // stream tip, which can run ahead of the scan node and would make the
+    // request fail (-32016) instead of returning a usable view.
+    let response = rpc_client
+        .send::<OptionalContext<Vec<RpcKeyedAccount>>>(
+            RpcRequest::GetProgramAccounts,
+            json!([PROGRAM_ID.to_string(), config]),
+        )
         .await?;
+    let (view_slot, keyed_accounts) = match response {
+        OptionalContext::Context(response) => (Some(response.context.slot), response.value),
+        OptionalContext::NoContext(value) => (None, value),
+    };
+    let accounts: Vec<(Pubkey, Account)> = keyed_accounts
+        .into_iter()
+        .filter_map(|entry| Some((entry.pubkey.parse().ok()?, entry.account.decode()?)))
+        .collect();
 
     let tasks = accounts.into_iter().filter_map(|(pubkey, acc)| {
         if acc.owner != PROGRAM_ID {
@@ -89,7 +104,7 @@ pub async fn fetch_and_process_program_accounts(
                     &pubkey,
                     queue,
                     Arc::clone(&bytes),
-                    Some(view_slot),
+                    view_slot,
                 )
                 .await
             })

--- a/vrf-oracle/src/oracle/processor.rs
+++ b/vrf-oracle/src/oracle/processor.rs
@@ -42,19 +42,22 @@ pub async fn fetch_and_process_program_accounts(
     blockhash_cache: &Arc<BlockhashCache>,
     filters: Vec<RpcFilterType>,
 ) -> Result<()> {
+    // min_context_slot binds the scan to this view, so absences in the
+    // result are meaningful for items enqueued strictly before it. Minus
+    // one because the tracker may already know a just-created bank the
+    // RPC node has not finished processing.
+    let view_slot = oracle_client.slot_tracker.current().saturating_sub(1);
     let config = RpcProgramAccountsConfig {
         account_config: RpcAccountInfoConfig {
             commitment: Some(CommitmentConfig::processed()),
             encoding: Some(UiAccountEncoding::Base64),
+            min_context_slot: Some(view_slot),
             ..Default::default()
         },
         filters: Some(filters),
         ..Default::default()
     };
 
-    // Conservative view slot for the snapshot; absences in an older view
-    // must not cancel tasks for requests enqueued after it.
-    let view_slot = oracle_client.slot_tracker.current();
     let accounts = rpc_client
         .get_program_accounts_with_config(&PROGRAM_ID, config)
         .await?;

--- a/vrf-oracle/src/oracle/processor.rs
+++ b/vrf-oracle/src/oracle/processor.rs
@@ -57,11 +57,9 @@ pub async fn fetch_and_process_program_accounts(
         ..Default::default()
     };
 
-    // The response's context slot is the exact bank the scan was evaluated
-    // at, so absences in it are meaningful for items enqueued strictly
-    // earlier. Never demand a minimum slot here: the tracker follows the
-    // stream tip, which can run ahead of the scan node and would make the
-    // request fail (-32016) instead of returning a usable view.
+    // The response's context slot orders this view against notifications.
+    // Never demand a minimum slot: the tracker can run ahead of the scan
+    // node, failing the request (-32016) instead of returning a usable view.
     let response = rpc_client
         .send::<OptionalContext<Vec<RpcKeyedAccount>>>(
             RpcRequest::GetProgramAccounts,
@@ -109,6 +107,7 @@ pub async fn fetch_and_process_program_accounts(
                     queue,
                     Arc::clone(&bytes),
                     Some(view_slot),
+                    true,
                 )
                 .await
             })
@@ -125,6 +124,7 @@ pub async fn fetch_and_process_program_accounts(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn process_oracle_queue(
     oracle_client: &Arc<OracleClient>,
     rpc_client: &Arc<RpcClient>,
@@ -133,21 +133,30 @@ pub async fn process_oracle_queue(
     oracle_queue: &Queue,
     account_bytes: Arc<Vec<u8>>,
     notification_slot: Option<u64>,
+    is_snapshot: bool,
 ) {
     if oracle_queue_pda(&oracle_client.keypair.pubkey(), oracle_queue.index).0 == *queue
         && oracle_client.should_process_queue(rpc_client, queue).await
     {
-        // Process views in slot order per queue: an older snapshot racing a
-        // newer notification could otherwise resurrect a completed request
-        // (spawning a duplicate fulfillment) or cancel a live one.
-        if let Some(view_slot) = notification_slot {
+        // Apply views in per-queue slot order, holding the guard across the
+        // task-map mutations below so a stale view cannot resurrect or cancel
+        // requests. Snapshots lack intra-slot order: require strictly newer.
+        let _view_order_guard = {
             let mut latest_views = oracle_client.latest_view_slots.write().await;
-            let latest = latest_views.entry(queue.to_string()).or_insert(0);
-            if view_slot < *latest {
-                return;
+            if let Some(view_slot) = notification_slot {
+                let latest = latest_views.entry(queue.to_string()).or_insert(0);
+                let stale = if is_snapshot {
+                    view_slot <= *latest
+                } else {
+                    view_slot < *latest
+                };
+                if stale {
+                    return;
+                }
+                *latest = view_slot;
             }
-            *latest = view_slot;
-        }
+            latest_views
+        };
 
         if oracle_queue.item_count > 0 {
             info!(

--- a/vrf-oracle/src/oracle/processor.rs
+++ b/vrf-oracle/src/oracle/processor.rs
@@ -52,6 +52,9 @@ pub async fn fetch_and_process_program_accounts(
         ..Default::default()
     };
 
+    // Conservative view slot for the snapshot; absences in an older view
+    // must not cancel tasks for requests enqueued after it.
+    let view_slot = oracle_client.slot_tracker.current();
     let accounts = rpc_client
         .get_program_accounts_with_config(&PROGRAM_ID, config)
         .await?;
@@ -83,7 +86,7 @@ pub async fn fetch_and_process_program_accounts(
                     &pubkey,
                     queue,
                     Arc::clone(&bytes),
-                    None,
+                    Some(view_slot),
                 )
                 .await
             })
@@ -156,6 +159,17 @@ pub async fn process_oracle_queue(
             let previously_tracked: Vec<[u8; 32]> = inflight_for_queue.keys().cloned().collect();
             for tracked_id in previously_tracked {
                 if !current_ids.contains(&tracked_id) {
+                    // Removal happens strictly after enqueue, so an absence
+                    // from a view no newer than the enqueue slot predates the
+                    // request: skip it so a stale snapshot cannot cancel a
+                    // live fulfillment task.
+                    if let (Some(enqueue_slot), Some(view_slot)) =
+                        (inflight_for_queue.get(&tracked_id), notification_slot)
+                    {
+                        if view_slot <= *enqueue_slot {
+                            continue;
+                        }
+                    }
                     // Cancel any running task for this id
                     if let Some(handle) = tasks_for_queue.remove(&tracked_id) {
                         handle.abort();

--- a/vrf-oracle/src/oracle/processor.rs
+++ b/vrf-oracle/src/oracle/processor.rs
@@ -34,6 +34,7 @@ use tokio::task;
 
 const ANCHOR_CONSTRAINT_ADDRESS_ERROR: u32 = 2012;
 const BLOCKHASH_MAX_AGE: Duration = Duration::from_secs(3);
+const MAX_PRIORITY_FEE_MICRO_LAMPORTS: u64 = 200_000;
 
 pub async fn fetch_and_process_program_accounts(
     oracle_client: &Arc<OracleClient>,
@@ -224,6 +225,7 @@ pub async fn process_oracle_queue(
                     ProcessableItem(item)
                         .prepare_transaction(
                             &oracle_client_for_proc,
+                            &rpc_client,
                             &blockhash_cache,
                             &input_seed,
                             &prepared_vrf,
@@ -263,6 +265,7 @@ pub async fn process_oracle_queue(
                             ProcessableItem(item)
                                 .prepare_transaction(
                                     &oracle_client_for_proc,
+                                    &rpc_client,
                                     &blockhash_cache,
                                     &input_seed,
                                     &prepared_vrf,
@@ -333,6 +336,7 @@ pub async fn process_oracle_queue(
                             ProcessableItem(item)
                                 .prepare_transaction(
                                     &oracle_client_for_proc,
+                                    &rpc_client,
                                     &blockhash_cache,
                                     &input_seed,
                                     &prepared_vrf,
@@ -430,6 +434,7 @@ impl ProcessableItem {
     async fn prepare_transaction(
         &self,
         oracle_client: &OracleClient,
+        rpc_client: &RpcClient,
         blockhash_cache: &BlockhashCache,
         vrf_input: &[u8; 32],
         prepared_vrf: &PreparedVrf,
@@ -477,8 +482,20 @@ impl ProcessableItem {
         // Nonce: vary the compute limit so each retry is a distinct
         // transaction under the same cached blockhash.
         let budget = budget + (attempt % 256) as u32;
+        // Escalate the fee roughly every 3s the request stays unlanded; the
+        // cap bounds the spend to ~60k lamports at the 300k CU limit.
+        let priority_fee = (oracle_client.priority_fee(rpc_client).await << (attempt / 8).min(4))
+            .min(MAX_PRIORITY_FEE_MICRO_LAMPORTS);
+        let mut instructions = vec![ComputeBudgetInstruction::set_compute_unit_limit(budget), ix];
+        if priority_fee > 0 {
+            // Appended after the VRF instruction so its error index stays 1,
+            // which the send loop's error matching relies on.
+            instructions.push(ComputeBudgetInstruction::set_compute_unit_price(
+                priority_fee,
+            ));
+        }
         Transaction::new_signed_with_payer(
-            &[ComputeBudgetInstruction::set_compute_unit_limit(budget), ix],
+            &instructions,
             Some(&oracle_client.keypair.pubkey()),
             &[&oracle_client.keypair],
             blockhash,


### PR DESCRIPTION
- Snapshot pending queue items on every update-source (re)connect, so requests that land during a stream gap are processed immediately
- Reduce the periodic `getProgramAccounts` backstop scan from 30s to 5s
- Attach a priority fee to fulfillment transactions, sourced from `getPriorityFeeEstimate` (cached, with a fallback default) and escalating with retry attempts up to a fixed cap; zero on ephemeral rollups
- Apply queue views in per-queue slot order (scan view slot taken from the response context), so stale snapshots cannot cancel or duplicate in-flight fulfillments