### PR TITLE
fix: expire requests by their own creation timestamp

### DIFF
--- a/api/src/state/queue.rs
+++ b/api/src/state/queue.rs
@@ -42,7 +42,24 @@ pub struct QueueItem {
     pub used: u8,          // Flag: 1 = used, 0 = free (logically removed)
     pub identity_mode: u8, // 0 = legacy global identity, 1 = scoped per-callback identity
     pub identity_bump: u8, // bump for the scoped identity PDA (valid when identity_mode == 1)
-    pub _padding: [u8; 2],
+    /// Creation time in `CREATED_AT_UNIT_SECS` units, modulo ~72 h: an item
+    /// that old reads as fresh for one TTL per cycle.
+    pub created_at: u16,
+}
+
+/// Resolution of `QueueItem::created_at`.
+pub const CREATED_AT_UNIT_SECS: i64 = 4;
+
+impl QueueItem {
+    pub fn created_at_from(unix_timestamp: i64) -> u16 {
+        (unix_timestamp / CREATED_AT_UNIT_SECS) as u16
+    }
+
+    /// Wall-clock age given the current stamp (`created_at_from(now)`), taken
+    /// modulo the wrap.
+    pub fn age_secs(&self, now_stamp: u16) -> u64 {
+        now_stamp.wrapping_sub(self.created_at) as u64 * CREATED_AT_UNIT_SECS as u64
+    }
 }
 
 impl QueueItem {

--- a/program/src/purge_expired_requests.rs
+++ b/program/src/purge_expired_requests.rs
@@ -1,4 +1,3 @@
-use solana_program::epoch_schedule::EpochSchedule;
 use solana_program::msg;
 use solana_vrf_api::prelude::*;
 
@@ -29,48 +28,21 @@ pub fn process_purge_expired_requests(accounts: &[AccountInfo<'_>], data: &[u8])
             &solana_vrf_api::ID,
         )?;
 
-    // Measure request age in wall-clock seconds rather than a fixed slot count,
-    // using the current epoch's average slot duration, so expiry stays correct
-    // if the slot duration changes.
-    let clock = Clock::get()?;
-    let epoch_start_slot = EpochSchedule::get()?.get_first_slot_in_epoch(clock.epoch);
+    // Age is measured against the request's own creation timestamp, so expiry
+    // does not depend on the slot duration.
+    let now_stamp = QueueItem::created_at_from(Clock::get()?.unix_timestamp);
 
     // Borrow queue data and scan/remove expired items using QueueAccount view
     let mut acc_data = oracle_queue_info.try_borrow_mut_data()?;
     Queue::try_from_bytes(&acc_data)?;
     let mut queue_acc = QueueAccount::load(&mut acc_data)?;
 
-    // Age is measured in wall-clock seconds, derived from the epoch's average
-    // slot duration. The epoch-relative rate (elapsed_secs / elapsed_slots) is
-    // loop-invariant, so compute it once here rather than per item — that keeps
-    // a single-pass purge of a full queue well within the compute budget.
-    //
-    // All values are bounded by a single epoch (elapsed_slots <= slots-per-epoch,
-    // elapsed_secs <= the epoch's wall-clock length), so native u64 arithmetic
-    // cannot overflow — much cheaper on SBF than emulated 128-bit math. The
-    // saturating_mul below is purely defensive. Clamps keep values >= 0/1.
-    let current_slot = clock.slot;
-    let elapsed_slots = current_slot.saturating_sub(epoch_start_slot).max(1);
-    let elapsed_secs = clock
-        .unix_timestamp
-        .saturating_sub(clock.epoch_start_timestamp)
-        .max(0) as u64;
-
-    // Scan and remove expired items in a single O(n) pass, so purging stays
-    // within the compute budget even when the queue is completely full.
+    // Single O(n) pass so a full queue stays within the compute budget.
     let mut total_cost: u64 = 0;
     let mut removed: usize = 0;
     msg!("Items in the queue: {}", queue_acc.len());
     queue_acc.remove_items_matching(
-        |item| {
-            // Only age accrued within the current epoch is counted (slot_age is
-            // capped at elapsed_slots), so the estimate can never exceed the real
-            // time elapsed since the epoch start — a request is never expired
-            // before its TTL, even for requests that span an epoch boundary.
-            let slot_age = current_slot.saturating_sub(item.slot).min(elapsed_slots);
-            let age_secs = slot_age.saturating_mul(elapsed_secs) / elapsed_slots;
-            age_secs > QUEUE_TTL_SECONDS
-        },
+        |item| item.age_secs(now_stamp) > QUEUE_TTL_SECONDS,
         |item| {
             let cost = if item.priority_request == 1 {
                 VRF_HIGH_PRIORITY_LAMPORTS_COST

--- a/program/src/request_randomness.rs
+++ b/program/src/request_randomness.rs
@@ -120,7 +120,7 @@ pub fn process_request_randomness(
             used: 1,
             identity_mode: scoped as u8,
             identity_bump,
-            _padding: [0u8; 2],
+            created_at: QueueItem::created_at_from(time),
         };
 
         // Append the item to the queue (writes discriminator, metas, args into the

--- a/program/tests/purge_stress_test.rs
+++ b/program/tests/purge_stress_test.rs
@@ -7,10 +7,21 @@
 //! never land; after the fix it must succeed and fully drain the queue.
 
 use solana_compute_budget_interface::ComputeBudgetInstruction;
-use solana_program_test::{processor, ProgramTest};
+use solana_program::clock::Clock;
+use solana_program_test::{processor, ProgramTest, ProgramTestContext};
 use solana_sdk::account::Account;
 use solana_sdk::{signature::Keypair, signer::Signer, transaction::Transaction};
 use solana_vrf_api::prelude::*;
+
+/// Clock time for the purge. Expired items are stamped 600 s earlier, live
+/// items with this value.
+const NOW: i64 = 1_789_086_305;
+
+async fn set_now(context: &mut ProgramTestContext) {
+    let mut clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
+    clock.unix_timestamp = NOW;
+    context.set_sysvar(&clock);
+}
 
 /// Mainnet queue account size (advisory: 29,976 usable bytes after
 /// discriminator + header, i.e. 312 minimal 96-byte requests).
@@ -19,8 +30,8 @@ const QUEUE_ACCOUNT_SIZE: usize = 30_000;
 const MAINNET_CU_LIMIT: u32 = 1_400_000;
 
 /// Build the exact byte content of a full queue account whose items are all
-/// expired (slot 0), using the real `QueueAccount` implementation so the
-/// layout is identical to what on-chain requests produce.
+/// expired (created 600 s before `NOW`), using the real `QueueAccount`
+/// implementation so the layout is identical to what on-chain requests produce.
 fn full_expired_queue(index: u8, account_size: usize) -> (Vec<u8>, usize) {
     let mut data = vec![0u8; account_size];
     data[..8].copy_from_slice(&AccountDiscriminator::Queue.to_bytes());
@@ -28,7 +39,7 @@ fn full_expired_queue(index: u8, account_size: usize) -> (Vec<u8>, usize) {
     queue.header.index = index;
 
     let expired_item = QueueItem {
-        slot: 0,
+        created_at: QueueItem::created_at_from(NOW - 600),
         ..QueueItem::default()
     };
     let mut added = 0usize;
@@ -91,20 +102,7 @@ async fn purge_full_queue_within_mainnet_compute_budget() {
     );
 
     // Advance past the TTL so every staged request is expired.
-    let slot = banks
-        .get_sysvar::<solana_program::clock::Clock>()
-        .await
-        .unwrap()
-        .slot;
-    context.warp_to_slot(slot + 1_000).unwrap();
-    let mut clock = context
-        .banks_client
-        .get_sysvar::<solana_program::clock::Clock>()
-        .await
-        .unwrap();
-    // Expiry is wall-clock based; push the Clock timestamp well past the TTL.
-    clock.unix_timestamp = clock.epoch_start_timestamp + 1_000_000;
-    context.set_sysvar(&clock);
+    set_now(&mut context).await;
 
     // Execute the real purge instruction under the mainnet CU cap.
     let budget_ix = ComputeBudgetInstruction::set_compute_unit_limit(MAINNET_CU_LIMIT);
@@ -185,7 +183,7 @@ async fn purge_mixed_queue_keeps_live_requests() {
         .await
         .unwrap()
         .slot
-        + 1_000_000; // far in the future: never expires during the test
+        + 1_000_000; // distinct from the expired items' slot 0
 
     // 312 items: alternate expired/live for the first 200 (middle holes),
     // then 112 expired at the tail (trailing holes).
@@ -199,6 +197,7 @@ async fn purge_mixed_queue_keeps_live_requests() {
             let is_live = i < 200 && i % 2 == 0;
             let item = QueueItem {
                 slot: if is_live { live_slot } else { 0 },
+                created_at: QueueItem::created_at_from(if is_live { NOW } else { NOW - 600 }),
                 id: [i as u8; 32],
                 ..QueueItem::default()
             };
@@ -225,20 +224,7 @@ async fn purge_mixed_queue_keeps_live_requests() {
     );
 
     // Advance past the TTL and purge.
-    let slot = banks
-        .get_sysvar::<solana_program::clock::Clock>()
-        .await
-        .unwrap()
-        .slot;
-    context.warp_to_slot(slot + 1_000).unwrap();
-    let mut clock = context
-        .banks_client
-        .get_sysvar::<solana_program::clock::Clock>()
-        .await
-        .unwrap();
-    // Expiry is wall-clock based; push the Clock timestamp well past the TTL.
-    clock.unix_timestamp = clock.epoch_start_timestamp + 1_000_000;
-    context.set_sysvar(&clock);
+    set_now(&mut context).await;
     let purge_ix = purge_expired_requests(oracle_keypair.pubkey(), 0);
     let blockhash = banks.get_latest_blockhash().await.unwrap();
     let tx = Transaction::new_signed_with_payer(
@@ -322,20 +308,7 @@ async fn purge_max_size_queue_within_mainnet_compute_budget() {
 
     let mut context = program_test.start_with_context().await;
     let banks = context.banks_client.clone();
-    let slot = banks
-        .get_sysvar::<solana_program::clock::Clock>()
-        .await
-        .unwrap()
-        .slot;
-    context.warp_to_slot(slot + 1_000).unwrap();
-    let mut clock = context
-        .banks_client
-        .get_sysvar::<solana_program::clock::Clock>()
-        .await
-        .unwrap();
-    // Expiry is wall-clock based; push the Clock timestamp well past the TTL.
-    clock.unix_timestamp = clock.epoch_start_timestamp + 1_000_000;
-    context.set_sysvar(&clock);
+    set_now(&mut context).await;
 
     let budget_ix = ComputeBudgetInstruction::set_compute_unit_limit(MAINNET_CU_LIMIT);
     let purge_ix = purge_expired_requests(oracle_keypair.pubkey(), 0);

--- a/program/tests/purge_ttl_test.rs
+++ b/program/tests/purge_ttl_test.rs
@@ -1,22 +1,24 @@
-//! Requests expire by wall-clock time, not a fixed slot count. Drives the real
-//! purge instruction with a controlled Clock so the elapsed time is exact.
+//! Requests expire by wall-clock age from their own creation timestamp.
+//! Drives the real purge instruction with a controlled Clock.
 
 use solana_program::clock::Clock;
-use solana_program_test::{processor, ProgramTest};
+use solana_program::epoch_schedule::EpochSchedule;
+use solana_program_test::{processor, ProgramTest, ProgramTestContext};
 use solana_sdk::account::Account;
 use solana_sdk::{signature::Keypair, signer::Signer, transaction::Transaction};
 use solana_vrf_api::prelude::*;
 
-/// Program-owned queue at index 0 holding items at the given creation slots.
-fn queue_with_items(size: usize, slots: &[u64]) -> Vec<u8> {
+/// Program-owned queue at index 0 holding items with the given `created_at`
+/// stamps. Item ids are 1-based positions, so survivors can be asserted by id.
+fn queue_with_items(size: usize, created_at: &[u16]) -> Vec<u8> {
     let mut data = vec![0u8; size];
     data[..8].copy_from_slice(&AccountDiscriminator::Queue.to_bytes());
     {
         let mut queue = QueueAccount::load(&mut data).unwrap();
         queue.header.index = 0;
-        for (i, slot) in slots.iter().enumerate() {
+        for (i, stamp) in created_at.iter().enumerate() {
             let item = QueueItem {
-                slot: *slot,
+                created_at: *stamp,
                 id: [i as u8 + 1; 32],
                 ..QueueItem::default()
             };
@@ -26,14 +28,18 @@ fn queue_with_items(size: usize, slots: &[u64]) -> Vec<u8> {
     data
 }
 
-#[tokio::test]
-async fn purge_expires_by_wall_clock_time() {
+struct Harness {
+    context: ProgramTestContext,
+    oracle: Keypair,
+    queue_addr: Pubkey,
+}
+
+async fn start() -> Harness {
     let mut program_test = ProgramTest::new(
         "solana_vrf_program",
         solana_vrf_api::ID,
         processor!(solana_vrf_program::process_instruction),
     );
-
     let oracle = Keypair::new();
     let queue_addr = oracle_queue_pda(&oracle.pubkey(), 0).0;
     program_test.add_account(
@@ -46,50 +52,112 @@ async fn purge_expires_by_wall_clock_time() {
             rent_epoch: 0,
         },
     );
-    // Item 1 created at slot 0 (old), item 2 at slot 900 (fresh).
-    program_test.add_account(
+    let context = program_test.start_with_context().await;
+    Harness {
+        context,
+        oracle,
         queue_addr,
-        Account {
-            lamports: 10_000_000_000,
-            data: queue_with_items(9_500, &[0, 900]),
-            owner: solana_vrf_api::ID,
-            executable: false,
-            rent_epoch: 0,
-        },
-    );
+    }
+}
 
-    let ctx = program_test.start_with_context().await;
-    let banks = ctx.banks_client.clone();
+impl Harness {
+    fn stage_queue(&mut self, created_at: &[u16]) {
+        self.context.set_account(
+            &self.queue_addr,
+            &Account {
+                lamports: 10_000_000_000,
+                data: queue_with_items(9_500, created_at),
+                owner: solana_vrf_api::ID,
+                executable: false,
+                rent_epoch: 0,
+            }
+            .into(),
+        );
+    }
 
-    // Controlled clock in epoch 0 (which starts at slot 0): 1000 slots and
-    // 130 s have elapsed since epoch start => ~0.13 s/slot.
-    //   item 1: age = 1000 * 130 / 1000 = 130 s  > 120 => purged
-    //   item 2: age =  100 * 130 / 1000 =  13 s  < 120 => kept
-    let mut clock = banks.get_sysvar::<Clock>().await.unwrap();
-    clock.epoch = 0;
-    clock.slot = 1000;
+    async fn set_time(&mut self, unix_timestamp: i64) {
+        let mut clock = self
+            .context
+            .banks_client
+            .get_sysvar::<Clock>()
+            .await
+            .unwrap();
+        clock.unix_timestamp = unix_timestamp;
+        self.context.set_sysvar(&clock);
+    }
+
+    /// Run the purge and return the surviving item ids.
+    async fn purge(&mut self) -> Vec<u8> {
+        let banks = self.context.banks_client.clone();
+        let purge_ix = purge_expired_requests(self.oracle.pubkey(), 0);
+        let bh = banks.get_latest_blockhash().await.unwrap();
+        let tx = Transaction::new_signed_with_payer(
+            &[purge_ix],
+            Some(&self.context.payer.pubkey()),
+            &[&self.context.payer],
+            bh,
+        );
+        banks.process_transaction(tx).await.expect("purge failed");
+        let acct = banks.get_account(self.queue_addr).await.unwrap().unwrap();
+        let mut data = acct.data.clone();
+        let queue = QueueAccount::load(&mut data).unwrap();
+        queue.iter_items().map(|it| it.id[0]).collect()
+    }
+}
+
+const NOW: i64 = 1_789_086_305;
+
+#[tokio::test]
+async fn purge_expires_by_wall_clock_time() {
+    let mut h = start().await;
+    // item 1: 124 s old => purged; item 2: 116 s old => kept.
+    h.stage_queue(&[
+        QueueItem::created_at_from(NOW - 124),
+        QueueItem::created_at_from(NOW - 116),
+    ]);
+    h.set_time(NOW).await;
+
+    assert_eq!(h.purge().await, vec![2]);
+}
+
+/// Age must not depend on slots or epochs: devnet's stale EpochSchedule
+/// (8,192 slots per epoch against a 432,000-slot clock) changes nothing.
+#[tokio::test]
+async fn purge_ignores_epoch_sysvars() {
+    let mut h = start().await;
+    h.context
+        .set_sysvar(&EpochSchedule::custom(8_192, 8_192, false));
+    let mut clock = h.context.banks_client.get_sysvar::<Clock>().await.unwrap();
+    clock.slot = 496_404_516;
+    clock.epoch = 1_149;
     clock.epoch_start_timestamp = 0;
-    clock.unix_timestamp = 130;
-    ctx.set_sysvar(&clock);
+    h.context.set_sysvar(&clock);
 
-    let purge_ix = purge_expired_requests(oracle.pubkey(), 0);
-    let bh = banks.get_latest_blockhash().await.unwrap();
-    let tx = Transaction::new_signed_with_payer(
-        &[purge_ix],
-        Some(&ctx.payer.pubkey()),
-        &[&ctx.payer],
-        bh,
-    );
-    banks.process_transaction(tx).await.expect("purge failed");
+    h.stage_queue(&[
+        QueueItem::created_at_from(NOW - 40 * 3_600),
+        QueueItem::created_at_from(NOW - 30),
+    ]);
+    h.set_time(NOW).await;
 
-    // Only the fresh request (id 2) survives.
-    let acct = banks.get_account(queue_addr).await.unwrap().unwrap();
-    let mut data = acct.data.clone();
-    let queue = QueueAccount::load(&mut data).unwrap();
-    let ids: Vec<u8> = queue.iter_items().map(|it| it.id[0]).collect();
-    assert_eq!(
-        ids,
-        vec![2],
-        "the old request must be purged, the fresh one kept"
-    );
+    assert_eq!(h.purge().await, vec![2]);
+}
+
+/// The 16-bit stamp wraps; ages are taken modulo the wrap.
+#[tokio::test]
+async fn purge_handles_created_at_wrap() {
+    let mut h = start().await;
+    // `now` is 8 s past a wrap boundary of the stamp.
+    let now = ((NOW / CREATED_AT_UNIT_SECS) / 65_536 + 1) * 65_536 * CREATED_AT_UNIT_SECS + 8;
+    assert_eq!(QueueItem::created_at_from(now), 2);
+    // item 1: created 200 s before the wrap => purged
+    // item 2: created  60 s before the wrap => kept
+    // item 3: created in this unit => kept
+    h.stage_queue(&[
+        QueueItem::created_at_from(now - 208),
+        QueueItem::created_at_from(now - 68),
+        QueueItem::created_at_from(now),
+    ]);
+    h.set_time(now).await;
+
+    assert_eq!(h.purge().await, vec![2, 3]);
 }

--- a/vrf-oracle/src/oracle/client.rs
+++ b/vrf-oracle/src/oracle/client.rs
@@ -10,7 +10,6 @@ use solana_client::{
 };
 use solana_commitment_config::CommitmentConfig;
 use solana_sdk::{pubkey::Pubkey, signature::Keypair};
-use solana_vrf_api::prelude::QUEUE_TTL_SECONDS;
 use std::{
     collections::HashMap,
     sync::{
@@ -68,8 +67,6 @@ const NON_ER_EARLY_SEND_BONUS: Duration = Duration::from_millis(400);
 const NON_ER_MIN_SLOT_DURATION: Duration = Duration::from_millis(200);
 const MIN_SLOT_SAMPLE: Duration = Duration::from_millis(1);
 const MIN_SLOT_SAMPLES: u8 = 3;
-/// Assumed slot duration before the tracker has measured one.
-const NOMINAL_SLOT_DURATION: Duration = Duration::from_millis(500);
 
 #[derive(Clone)]
 pub struct SlotTracker {
@@ -108,22 +105,6 @@ impl SlotTracker {
 
     pub fn current(&self) -> u64 {
         *self.sender.borrow()
-    }
-
-    /// Number of slots that currently approximates `QUEUE_TTL_SECONDS` of
-    /// wall-clock time, using the measured slot duration so it tracks changes
-    /// to Solana's block time. Falls back to a nominal rate until enough
-    /// samples have been collected, so a single noisy measurement can't shrink
-    /// the threshold and cause premature purging.
-    pub fn ttl_slots(&self) -> u64 {
-        let timing = self.timing.lock().unwrap();
-        let slot_duration = if timing.samples >= MIN_SLOT_SAMPLES {
-            timing.slot_duration.unwrap_or(NOMINAL_SLOT_DURATION)
-        } else {
-            NOMINAL_SLOT_DURATION
-        };
-        let slot_ms = slot_duration.as_millis().max(1);
-        (QUEUE_TTL_SECONDS as u128 * 1000 / slot_ms) as u64
     }
 
     pub fn update(&self, slot: u64) {

--- a/vrf-oracle/src/oracle/processor.rs
+++ b/vrf-oracle/src/oracle/processor.rs
@@ -40,12 +40,20 @@ const ANCHOR_CONSTRAINT_ADDRESS_ERROR: u32 = 2012;
 /// Cap on the exponential wait between purge attempts for one request.
 const PURGE_RETRY_MAX_SLOTS: u64 = 256;
 
+/// Host clock may trail the cluster clock that stamped the request; a stamp
+/// this far in the future reads as age 0 instead of wrapping.
+const CLOCK_SKEW_UNITS: u16 = 15;
+
 /// Wall-clock age of a request, the same rule the program purges by.
 fn age_secs(item: &QueueItem) -> u64 {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| d.as_secs() as i64);
-    item.age_secs(QueueItem::created_at_from(now))
+    let now_stamp = QueueItem::created_at_from(now);
+    if item.created_at.wrapping_sub(now_stamp) <= CLOCK_SKEW_UNITS {
+        return 0;
+    }
+    item.age_secs(now_stamp)
 }
 const BLOCKHASH_MAX_AGE: Duration = Duration::from_secs(3);
 const MAX_PRIORITY_FEE_LAMPORTS: u64 = 60_000;

--- a/vrf-oracle/src/oracle/processor.rs
+++ b/vrf-oracle/src/oracle/processor.rs
@@ -26,19 +26,27 @@ use solana_vrf::vrf::{compute_vrf, verify_vrf};
 use solana_vrf_api::{
     prelude::{
         provide_randomness_with_identity_mode, purge_expired_requests, Queue, QueueAccount,
-        QueueItem, SolanaVrfError,
+        QueueItem, SolanaVrfError, QUEUE_TTL_SECONDS,
     },
     state::oracle_queue_pda,
     ID as PROGRAM_ID,
 };
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::task;
 
 const ANCHOR_CONSTRAINT_ADDRESS_ERROR: u32 = 2012;
 /// Cap on the exponential wait between purge attempts for one request.
 const PURGE_RETRY_MAX_SLOTS: u64 = 256;
+
+/// Wall-clock age of a request, the same rule the program purges by.
+fn age_secs(item: &QueueItem) -> u64 {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs() as i64);
+    item.age_secs(QueueItem::created_at_from(now))
+}
 const BLOCKHASH_MAX_AGE: Duration = Duration::from_secs(3);
 const MAX_PRIORITY_FEE_LAMPORTS: u64 = 60_000;
 
@@ -317,8 +325,7 @@ pub async fn process_oracle_queue(
                     let sent_early = attempt_slot < first_valid_slot;
                     let mut use_backoff = false;
                     // Past the TTL the prepared fulfilment is replaced by a purge.
-                    let expired = attempt_slot.saturating_sub(item.slot)
-                        > oracle_client_for_proc.slot_tracker.ttl_slots();
+                    let expired = age_secs(&item) > QUEUE_TTL_SECONDS;
                     let transaction = match prepared_transaction.take() {
                         Some(transaction) if !expired => transaction,
                         _ => {
@@ -378,16 +385,9 @@ pub async fn process_oracle_queue(
                                     use_backoff = false;
                                 }
                                 if code == ANCHOR_CONSTRAINT_ADDRESS_ERROR {
-                                    let purge_slot = item
-                                        .slot
-                                        .saturating_add(
-                                            oracle_client_for_proc.slot_tracker.ttl_slots(),
-                                        )
-                                        .saturating_add(1);
-                                    oracle_client_for_proc
-                                        .slot_tracker
-                                        .wait_for_slot(purge_slot)
-                                        .await;
+                                    let until_expiry =
+                                        QUEUE_TTL_SECONDS.saturating_sub(age_secs(&item)) + 1;
+                                    tokio::time::sleep(Duration::from_secs(until_expiry)).await;
                                     blockhash_cache.refresh_if_stale(BLOCKHASH_MAX_AGE).await;
                                     continue;
                                 }
@@ -520,11 +520,7 @@ impl ProcessableItem {
         attempt: u64,
     ) -> Transaction {
         let (blockhash, _) = blockhash_cache.get_blockhash_and_slot().await;
-        let current_slot = oracle_client.slot_tracker.current();
-
-        // Check whether the request is expired
-        let age = current_slot.saturating_sub(self.0.slot);
-        let is_purge = age > oracle_client.slot_tracker.ttl_slots();
+        let is_purge = age_secs(&self.0) > QUEUE_TTL_SECONDS;
         let ix = if is_purge {
             // Build purge instruction for the queue index
             purge_expired_requests(oracle_client.keypair.pubkey(), queue_meta.index)

--- a/vrf-oracle/src/oracle/processor.rs
+++ b/vrf-oracle/src/oracle/processor.rs
@@ -37,6 +37,8 @@ use std::time::Duration;
 use tokio::task;
 
 const ANCHOR_CONSTRAINT_ADDRESS_ERROR: u32 = 2012;
+/// Cap on the exponential wait between purge attempts for one request.
+const PURGE_RETRY_MAX_SLOTS: u64 = 256;
 const BLOCKHASH_MAX_AGE: Duration = Duration::from_secs(3);
 const MAX_PRIORITY_FEE_LAMPORTS: u64 = 60_000;
 
@@ -275,6 +277,7 @@ pub async fn process_oracle_queue(
                 }
                 let mut attempts = 0;
                 let mut backoff_attempts = 0;
+                let mut purges_sent: u32 = 0;
                 let mut first_legal_attempt_pending = false;
                 blockhash_cache.refresh_if_stale(BLOCKHASH_MAX_AGE).await;
                 let prepared_vrf =
@@ -313,13 +316,11 @@ pub async fn process_oracle_queue(
                     let attempt_slot = oracle_client_for_proc.slot_tracker.current();
                     let sent_early = attempt_slot < first_valid_slot;
                     let mut use_backoff = false;
+                    // Past the TTL the prepared fulfilment is replaced by a purge.
+                    let expired = attempt_slot.saturating_sub(item.slot)
+                        > oracle_client_for_proc.slot_tracker.ttl_slots();
                     let transaction = match prepared_transaction.take() {
-                        Some(transaction)
-                            if attempt_slot.saturating_sub(item.slot)
-                                <= oracle_client_for_proc.slot_tracker.ttl_slots() =>
-                        {
-                            transaction
-                        }
+                        Some(transaction) if !expired => transaction,
                         _ => {
                             ProcessableItem(item)
                                 .prepare_transaction(
@@ -350,11 +351,17 @@ pub async fn process_oracle_queue(
                     .await;
                     let early_send_accepted = sent_early && result.is_ok();
                     match result {
-                        Ok(signature) => trace!(
-                            "Transaction: {}, for id {}",
-                            signature,
-                            Pubkey::new_from_array(item.id)
-                        ),
+                        Ok(signature) => {
+                            if expired {
+                                // Accepted purge that may leave the item in place: back off.
+                                purges_sent += 1;
+                            }
+                            trace!(
+                                "Transaction: {}, for id {}",
+                                signature,
+                                Pubkey::new_from_array(item.id)
+                            )
+                        }
                         Err(error) => {
                             use_backoff = true;
                             if let Some(TransactionError::InstructionError(
@@ -409,12 +416,18 @@ pub async fn process_oracle_queue(
                                 .await,
                         );
                     }
-                    let retry_slots = if use_backoff {
+                    let purge_delay = if purges_sent > 0 {
+                        (1u64 << purges_sent.min(8)).min(PURGE_RETRY_MAX_SLOTS)
+                    } else {
+                        0
+                    };
+                    let error_delay = if use_backoff {
                         (1u64 << backoff_attempts.min(5)).min(32)
                     } else {
                         backoff_attempts = 0;
                         1
                     };
+                    let retry_slots = purge_delay.max(error_delay);
                     blockhash_cache.refresh_if_stale(BLOCKHASH_MAX_AGE).await;
                     oracle_client_for_proc
                         .slot_tracker
@@ -424,6 +437,8 @@ pub async fn process_oracle_queue(
                         tokio::time::sleep(oracle_client_for_proc.slot_tracker.early_send_grace())
                             .await;
                     }
+                    // A long purge backoff can outlive the cached blockhash.
+                    blockhash_cache.refresh_if_stale(BLOCKHASH_MAX_AGE).await;
                     attempts = next_attempt;
                     if use_backoff {
                         backoff_attempts += 1;


### PR DESCRIPTION
Requests now carry their own creation time and expire by comparing it to `Clock.unix_timestamp`. Expiry no longer depends on the slot duration or on the `EpochSchedule` sysvar.

- `QueueItem.created_at`: creation time in 4 s units, 16-bit wrapping, stored in the former padding bytes. Layout and size unchanged.
- Purge: `age_secs(now) > QUEUE_TTL_SECONDS`, division-free per item; the 512 KiB max-size purge stays within the mainnet compute cap.
- Oracle: a purge that is accepted but leaves the request in place backs off exponentially (up to 256 slots) instead of retrying every slot; error backoff is preserved and the blockhash is refreshed after the wait.

Tests cover wall-clock expiry, stamp wrap-around, and independence from `EpochSchedule`. Requests already queued at upgrade time have a zero stamp and read as an arbitrary age.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Queue requests now expire based on their actual wall-clock age, improving accuracy regardless of epoch timing.
  - Expiration remains reliable across timestamp wraparound scenarios.
  - Purge processing now uses progressively longer retry delays after repeated purge attempts, reducing unnecessary retries.
  - Long retry delays now refresh transaction timing information to improve processing reliability.
  - Expiration handling is more resilient to minor clock differences between systems.

- **Tests**
  - Expanded coverage for wall-clock expiration, epoch-independent behavior, timestamp wraparound, and mixed queue contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->